### PR TITLE
Add av package constraint as >=7 doesn't support ffmpeg 3.x

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -20,3 +20,6 @@ nmos-common==0.19.18
 python-dateutil>=2.4.2,<2.8.1
 oauthlib<3.0.0
 requests-oauthlib<1.2.0
+
+# Requirements due to av<7.0.0
+av<7.0.0


### PR DESCRIPTION
Confirmed that PyAV doesn't and won't support FFmpeg 3.x in av >= 7.0.0: https://github.com/mikeboers/PyAV/issues/605

I will add the same to the dev branch if accepted.