### PR TITLE
Add new sanic constraints

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -29,4 +29,5 @@ requests-oauthlib<1.2.0
 av<7.0.0
 
 # Requirements due to sanic
-httpx==0.11.1
+httpx==0.9.3
+sanic==19.12.2


### PR DESCRIPTION
As discussed on Slack this should resolve the issues we are seeing with sanic/httpx incompatibilities. This is a result of the issues currently being addressed in https://github.com/huge-success/sanic/pull/1806. The sanic pin is being used to prevent a sudden breakage after the next sanic release, so we can remove the httpx pin in a managed way.