### PR TITLE
Remove PyAV constraint as >=7.0.0 is now supported

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -25,9 +25,6 @@ python-dateutil>=2.4.2,<2.8.1
 oauthlib<3.0.0
 requests-oauthlib<1.2.0
 
-# Requirements due to av<7.0.0
-av<7.0.0
-
 # Requirements due to sanic
 httpx==0.9.3
 sanic==19.12.2


### PR DESCRIPTION
This has become an issue in Bobcat, and probably elsewhere, because constraint files are now being added. It wasn't an issue in Squirrel because Squirrel didn't use PyAV.