### PR TITLE
Pin watchtower back to 0.7 to keep compatability with boto3 < 1.9.252

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -9,6 +9,7 @@ botocore>=1.12.252,<1.12.253
 boto3==1.9.252
 
 # Requirements due to botocore>=1.12.252,<1.12.253
+watchtower>=0.7.3,<0.8.0
 jmespath>=0.7.1,<1.0.0
 docutils>=0.10,<0.16
 urllib3>=1.20,<1.26


### PR DESCRIPTION
Pin watchtower to < 0.8.0 for compatibility with our boto pinning.

No clue why git thinks the last line of the file has a change...