### PR TITLE
Pin yarl before 1.6.0 to keep query string escaping working

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -23,3 +23,6 @@ s3transfer>=0.3.0,<0.4.0
 # Requirements due to sanic
 httpx==0.9.3
 sanic==19.12.2
+
+# yarl 1.6.0 does not unescape query strings like 1.5.1 does
+yarl<1.6.0


### PR DESCRIPTION
For
"
from yarl import URL
URL.build(scheme="http", host="example.com", query="timerange=%5B123:0_456:0)").query
"

For yarl 1.5.1, this results in <MultiDictProxy('timerange': '[123:0_456:0)')>
For yarl 1.6.0, this results in <MultiDictProxy('timerange': '%5B123:0_456:0)')>

Tested in Squirrel: https://jenkins.rd.bbc.co.uk/job/apmm-repos/job/rd-cloudfit-squirrel-media-store/job/philipn-test-yarl/4/
