### PR TITLE
Add dateutil pin from other services

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -28,3 +28,6 @@ sanic==19.12.2
 
 # yarl 1.6.0 does not unescape query strings like 1.5.1 does
 yarl<1.6.0
+
+# Requirements due to python-dateutil 2.8.1 breaking other libraries (see https://github.com/boto/botocore/commit/e87e7a7)
+python-dateutil>=2.1,<2.8.1


### PR DESCRIPTION
We pin dateutil<2.8.1 in several other places, most notably cloudagnostic, due to botocore incompatibility.
See also https://github.com/boto/botocore/commit/e87e7a7

Fixes Weasel build failures - see https://jenkins.rd.bbc.co.uk/job/apmm-repos/job/rd-cloudfit-weasel-media-processing-framework/job/sammg-fix-deps/5/console for passing build