### PR TITLE
Pin uvloop to last Py36 version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -25,6 +25,7 @@ s3transfer>=0.3.0,<0.4.0
 # Requirements due to sanic
 httpx==0.9.3
 sanic==19.12.2
+uvloop<0.15.0  # uvloop no longer supports Python 3.6 from v0.15.0
 
 # yarl 1.6.0 does not unescape query strings like 1.5.1 does
 yarl<1.6.0


### PR DESCRIPTION
uvloop 0.15.0 onwards requires Python 3.7 or better, and we use Python 3.6. Fortunately the new resolver neatly takes care of this, so this fixes the repos that haven't moved to it yet.

Tested on Bobcat in https://jenkins.rd.bbc.co.uk/job/apmm-repos/job/rd-cloudfit-bobcat-file-packaging/job/sammg-uvloop-test/2